### PR TITLE
fix if else syntax

### DIFF
--- a/R/snippets.R
+++ b/R/snippets.R
@@ -22,12 +22,12 @@ sb_add_snippets <- function(sn_file = "~/.R/snippets/r.snippets"){
       paste(collapse = "\n") %>%
       cat(file = sn_file)
   }
-  if (res){
+  else if (res){
     message("Done!")
     message("Restart RStudio to have access to the snippets.")
-  } else {
+  } else
     message("Copy not done")
-  }
+
 }
 
 # Make snippets


### PR DESCRIPTION
Function `sb_add_snippets()`  throws  an error : "Error in if (res) { : argument is of zero length."
I changed the syntax and was able to add the snippets.