### PR TITLE
fix typo in sb_add_snippets() installation description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You can install `shinybones` from github:
 remotes::install_github('ramnathv/shinybones')
 ```
 
-`shinybones` ships with two useful snippets `stpage` and `stcomponent` that lets you create `page` and `component` modules that follow the conventions. You can install it by running `st_add_snippets`. Note that you will need to restart RStudio for the snippets to be usable.
+`shinybones` ships with two useful snippets `stpage` and `stcomponent` that lets you create `page` and `component` modules that follow the conventions. You can install it by running `sb_add_snippets`. Note that you will need to restart RStudio for the snippets to be usable.
 
 ```r
 shinybones::sb_add_snippets()


### PR DESCRIPTION
In the installation section in the README, it reads use `st_use_snippets` when it should read `sb_use_snippets`